### PR TITLE
ReadWikiView의 툴바 수정 버튼을 누르면 EditWikiView을 sheet로 띄우도록 수정.

### DIFF
--- a/AppleKiwi/AppleKiwi.xcodeproj/project.pbxproj
+++ b/AppleKiwi/AppleKiwi.xcodeproj/project.pbxproj
@@ -17,6 +17,9 @@
 		83C7630027FD685200FDC8D0 /* AppleKiwiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C762FF27FD685200FDC8D0 /* AppleKiwiTests.swift */; };
 		83C7630A27FD685200FDC8D0 /* AppleKiwiUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C7630927FD685200FDC8D0 /* AppleKiwiUITests.swift */; };
 		83C7630C27FD685200FDC8D0 /* AppleKiwiUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C7630B27FD685200FDC8D0 /* AppleKiwiUITestsLaunchTests.swift */; };
+		F8C1163A27FEB49900AC6744 /* WikiModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C1163927FEB49900AC6744 /* WikiModel.swift */; };
+		F8C1163C27FEBB1300AC6744 /* TestWikiContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C1163B27FEBB1300AC6744 /* TestWikiContentView.swift */; };
+		F8C1164027FEC2F300AC6744 /* EditableMarkdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C1163F27FEC2F300AC6744 /* EditableMarkdownView.swift */; };
 		F8E7FBA627FD6E9D00CF3F7E /* ReadWikiView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E7FBA527FD6E9D00CF3F7E /* ReadWikiView.swift */; };
 		F8E7FBA927FD6F3F00CF3F7E /* MarkdownView in Frameworks */ = {isa = PBXBuildFile; productRef = F8E7FBA827FD6F3F00CF3F7E /* MarkdownView */; };
 		F8E7FBAB27FD73A000CF3F7E /* EditWikiView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E7FBAA27FD73A000CF3F7E /* EditWikiView.swift */; };
@@ -53,6 +56,9 @@
 		83C7630527FD685200FDC8D0 /* AppleKiwiUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AppleKiwiUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		83C7630927FD685200FDC8D0 /* AppleKiwiUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleKiwiUITests.swift; sourceTree = "<group>"; };
 		83C7630B27FD685200FDC8D0 /* AppleKiwiUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleKiwiUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		F8C1163927FEB49900AC6744 /* WikiModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikiModel.swift; sourceTree = "<group>"; };
+		F8C1163B27FEBB1300AC6744 /* TestWikiContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestWikiContentView.swift; sourceTree = "<group>"; };
+		F8C1163F27FEC2F300AC6744 /* EditableMarkdownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableMarkdownView.swift; sourceTree = "<group>"; };
 		F8E7FBA527FD6E9D00CF3F7E /* ReadWikiView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadWikiView.swift; sourceTree = "<group>"; };
 		F8E7FBAA27FD73A000CF3F7E /* EditWikiView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditWikiView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -154,8 +160,11 @@
 		F8E7FBA427FD6DA900CF3F7E /* View */ = {
 			isa = PBXGroup;
 			children = (
+				F8C1163B27FEBB1300AC6744 /* TestWikiContentView.swift */,
 				F8E7FBA527FD6E9D00CF3F7E /* ReadWikiView.swift */,
 				F8E7FBAA27FD73A000CF3F7E /* EditWikiView.swift */,
+				F8C1163F27FEC2F300AC6744 /* EditableMarkdownView.swift */,
+				F8C1163927FEB49900AC6744 /* WikiModel.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -298,11 +307,14 @@
 			files = (
 				2004978727FD6B8B00B217AC /* LoginView.swift in Sources */,
 				2004978927FD717000B217AC /* UserViewModel.swift in Sources */,
+				F8C1163C27FEBB1300AC6744 /* TestWikiContentView.swift in Sources */,
 				F8E7FBA627FD6E9D00CF3F7E /* ReadWikiView.swift in Sources */,
 				83C762F127FD685100FDC8D0 /* ContentView.swift in Sources */,
+				F8C1164027FEC2F300AC6744 /* EditableMarkdownView.swift in Sources */,
 				F8E7FBAB27FD73A000CF3F7E /* EditWikiView.swift in Sources */,
 				83C762EF27FD685100FDC8D0 /* AppleKiwiApp.swift in Sources */,
 				2004978B27FD72FD00B217AC /* SignInView.swift in Sources */,
+				F8C1163A27FEB49900AC6744 /* WikiModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AppleKiwi/AppleKiwi/View/EditWikiView.swift
+++ b/AppleKiwi/AppleKiwi/View/EditWikiView.swift
@@ -8,50 +8,27 @@
 import SwiftUI
 
 struct EditWikiView: View {
-    @State private var markdown: String = """
-    ### Hi there 👋
-    
-    I'm Danny, a software engineer 💻 currently working at [Takeaway.com](https://takeaway.com) 🍲🥡
-    
-    I have a passion for clean code, Java, teaching, PHP, Lifeguarding and Javascript
-    
-    My current side project is [Markdown Profile](https://markdownprofile.com)
-    
-    [LinkedIn 💼](https://linkedin.com/in/dannyverpoort)
-    
-    [Twitter 🐦](https://twitter.com/dannyverp)
-    
-    [Website 🌍](https://dannyverpoort.dev/)
-    
-    [Email 📬](mailto:hallo@dannyverpoort.nl)
-    """
+    @Binding var isShowingSheet: Bool
+    @EnvironmentObject var wikiSample: WikiModel
     
     var body: some View {
         VStack {
             HStack {
                 Text("**위키 수정**")
                     .padding()
-                    .font(.title)
-                
                 Spacer()
-                Button("수정 완료") {
-                    
-                }.padding()
+                Button("완료") {
+                    isShowingSheet.toggle()
+                }
+                .padding()
             }
             Divider()
             ScrollView(.vertical) {
-                VStack {
-                    TextEditor(text: $markdown)
-                        .padding()
-                        .frame(maxHeight: .infinity)
-                }
+                TextEditor(text: $wikiSample.bodyText)
+                    .padding()
+                    .frame(height: 800)
             }
         }
-    }
-}
-
-struct EditWikiView_Previews: PreviewProvider {
-    static var previews: some View {
-        EditWikiView()
+        
     }
 }

--- a/AppleKiwi/AppleKiwi/View/EditableMarkdownView.swift
+++ b/AppleKiwi/AppleKiwi/View/EditableMarkdownView.swift
@@ -1,0 +1,19 @@
+//
+//  EditableMarkdownView.swift
+//  AppleKiwi
+//
+//  Created by 임성균 on 2022/04/07.
+//
+
+import SwiftUI
+import MarkdownView
+
+struct EditableMarkdownView: View {
+    @Binding var bodyText: String
+    
+    var body: some View {
+        VStack {
+            MarkdownUI(body: bodyText)
+        }
+    }
+}

--- a/AppleKiwi/AppleKiwi/View/ReadWikiView.swift
+++ b/AppleKiwi/AppleKiwi/View/ReadWikiView.swift
@@ -9,39 +9,32 @@ import SwiftUI
 import MarkdownView
 
 struct ReadWikiView: View {
-    private var markdown: String = """
-    ### Hi there 👋
-    
-    I'm Danny, a software engineer 💻 currently working at [Takeaway.com](https://takeaway.com) 🍲🥡
-    
-    I have a passion for clean code, Java, teaching, PHP, Lifeguarding and Javascript
-    
-    My current side project is [Markdown Profile](https://markdownprofile.com)
-
-    [LinkedIn 💼](https://linkedin.com/in/dannyverpoort)
-    
-    [Twitter 🐦](https://twitter.com/dannyverp)
-    
-    [Website 🌍](https://dannyverpoort.dev/)
-    
-    [Email 📬](mailto:hallo@dannyverpoort.nl)
-    """
+    @State private var isShowingSheet: Bool = false
+    @StateObject var wikiSample = WikiModel.sample
     
     var body: some View {
-        HStack {
-            ScrollView {
-                VStack {
-                    HStack {
-                        Text("창브로")
-                            .font(.title)
-                            .bold()
-                        Spacer()
-                    }.padding()
-                    Divider()
-                    MarkdownUI(body: markdown)
-                        .padding()
+        ScrollView {
+            VStack {
+                HStack {
+                    Text("\(wikiSample.title)")
+                        .font(.title)
+                        .bold()
                     Spacer()
-                }
+                }.padding()
+                Divider()
+                EditableMarkdownView(bodyText: $wikiSample.bodyText)
+                    .padding()
+                Spacer()
+            }
+        }
+        .navigationBarTitle("위키 조회", displayMode: .inline)
+        .toolbar {
+            Button("위키 수정") {
+                isShowingSheet.toggle()
+            }
+            .sheet(isPresented: $isShowingSheet) {
+                EditWikiView(isShowingSheet: $isShowingSheet)
+                    .environmentObject(wikiSample)
             }
         }
     }

--- a/AppleKiwi/AppleKiwi/View/TestWikiContentView.swift
+++ b/AppleKiwi/AppleKiwi/View/TestWikiContentView.swift
@@ -1,0 +1,25 @@
+//
+//  TestWikiContentView.swift
+//  AppleKiwi
+//
+//  Created by 임성균 on 2022/04/07.
+//
+
+import SwiftUI
+
+struct TestWikiContentView: View {
+    
+    var body: some View {
+        NavigationView {
+            List {
+                NavigationLink("위키 조회", destination: ReadWikiView())
+            }
+        }
+    }
+}
+
+struct TestWikiContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        TestWikiContentView()
+    }
+}

--- a/AppleKiwi/AppleKiwi/View/WikiModel.swift
+++ b/AppleKiwi/AppleKiwi/View/WikiModel.swift
@@ -1,0 +1,36 @@
+//
+//  WikiModel.swift
+//  AppleKiwi
+//
+//  Created by 임성균 on 2022/04/07.
+//
+
+import Foundation
+
+class WikiModel: ObservableObject {
+    @Published var title: String
+    @Published var bodyText: String
+    
+    init(title: String, bodyText: String) {
+        self.title = title
+        self.bodyText = bodyText
+    }
+    
+    static var sample = WikiModel(title: "교관 키위", bodyText: """
+    ### Hi there 👋
+    
+    I'm Danny, a software engineer 💻 currently working at [Takeaway.com](https://takeaway.com) 🍲🥡
+    
+    I have a passion for clean code, Java, teaching, PHP, Lifeguarding and Javascript
+    
+    My current side project is [Markdown Profile](https://markdownprofile.com)
+    
+    [LinkedIn 💼](https://linkedin.com/in/dannyverpoort)
+    
+    [Twitter 🐦](https://twitter.com/dannyverp)
+    
+    [Website 🌍](https://dannyverpoort.dev/)
+    
+    [Email 📬](mailto:hallo@dannyverpoort.nl)
+    """)
+}


### PR DESCRIPTION
위키 페이지 흐름을 확인하기 위해 테스트용 TestWikiContentsView 생성. 나중에 쿠키가 만든 메인 페이지와 연결하면 지울 것.

Wiki 제목과 마크다운 본문을 뷰 내의 변수가 아니라 WikiModel에 새로 정의.

위키 내용을 수정하면 바로 반영되도록 하기 위해 EditableMarkdownView에서 작업 중.